### PR TITLE
new_page_extension should be md by default not html

### DIFF
--- a/.forestry/settings.yml
+++ b/.forestry/settings.yml
@@ -2,7 +2,7 @@
 upload_path: "/uploads/:year:/:month:/:day:"
 frontmatter_file_url_template: "/uploads/:year:/:month:/:day:"
 body_file_url_template: "/uploads/:year:/:month:/:day:"
-new_page_extension: html
+new_page_extension: md
 auto_deploy: false
 admin_path: ''
 webhook_url: 


### PR DESCRIPTION
The current default leaves users with an html file when they create a new post while I believe we should use markdown as a default instead.