### PR TITLE
Avoid creating new pages with default template

### DIFF
--- a/.forestry/settings.yml
+++ b/.forestry/settings.yml
@@ -16,7 +16,7 @@ sections:
   create: all
   templates:
   - landing-page
-  - default
+  - page
 - type: directory
   path: _people
   label: People


### PR DESCRIPTION
When a user adds a new page, he shouldn't be able to choose default, who is a meta template. 

This leads a user testing the demo to create a page without styles, and thus believing something is wrong.